### PR TITLE
Update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "microplugin": "0.0.3",
-    "sifter": "^0.4.0"
+    "sifter": "^0.5.1"
   },
   "devDependencies": {
     "grunt": "0.4.x",


### PR DESCRIPTION
In order to work with node 6, `sifter` had to be upgraded to `0.5.1`
